### PR TITLE
Remove hard-coding of `program` and `project` from sanitizer (resolves #26)

### DIFF
--- a/scripts/data_bleach.py
+++ b/scripts/data_bleach.py
@@ -59,8 +59,6 @@ def recursive_clear(d, context=None):
 def sanitize_bundle(bundle):
     metadata = bundle['data_bundle']['user_metadata']
     recursive_clear(metadata)
-    metadata['program'] = 'gtex'
-    metadata['project'] = 'GTEx-v7'
 
 
 def main(argv):


### PR DESCRIPTION
The sanitizer (data_bleach.py) will soon be used on data for multiple projects and must not hard-code the program and project name as it does now.