### PR TITLE
Sanitize metadata using values of the same type

### DIFF
--- a/scripts/data_bleach.py
+++ b/scripts/data_bleach.py
@@ -39,6 +39,23 @@ def is_protected_field(key, context):
     return not any([context + [key] == field for field in PUBLIC_FIELDS])
 
 
+def get_sanitized_value(value):
+    result = None
+    if value is None:
+        result = None
+    elif isinstance(value, str):
+        result = "--------" if len(value) > 0 else ""
+    elif isinstance(value, bool):
+        result = False
+    elif isinstance(value, float):
+        result = 0.0
+    elif isinstance(value, int):
+        result = 0
+    elif isinstance(value, list):
+        result = []
+    return result
+
+
 def recursive_clear(d, context=None):
     """
     clear the values of a dictionary unless the value is another dictionary
@@ -53,7 +70,7 @@ def recursive_clear(d, context=None):
             recursive_clear(val, context=context + [key])
         else:
             if is_protected_field(key, context):
-                d[key] = ''
+                d[key] = get_sanitized_value(d[key])
 
 
 def sanitize_bundle(bundle):


### PR DESCRIPTION
When sanitizing data with data_bleach.py the sanitized value
is now the same type as the original value.

Retaining the types of sanitized values now will help with a
smoother transition (of indexing, etc.) to the full/unsanitized data.

The current change has been manually tested with large NIH data sets.
@jessebrennan is developing a unit test for `data_bleach.py` and that will test preservation of the value types.

Resolves #31 